### PR TITLE
swithing ssd interface

### DIFF
--- a/TestShell/TestShell/cmd_factory.cpp
+++ b/TestShell/TestShell/cmd_factory.cpp
@@ -9,6 +9,7 @@
 #include "full_write_read_compare_ts.h"
 #include "partial_lba_write_ts.h"
 #include "write_read_aging_ts.h"
+#include "ssd_interface.h"
 
 static WriteCmd writeCmd;
 static ReadCmd readCmd;
@@ -25,7 +26,11 @@ CmdFactory& CmdFactory::getInstance()
 	static CmdFactory instance; 
 	return instance;
 }
-
+void CmdFactory::setSdd(SsdInterface* sdd) {
+	for (auto cmd : m_supportedCmds){
+		cmd->setSdd(sdd);
+	}
+}
 CmdInterface* CmdFactory::getCmd(const string& name) const {
 	for (auto& cmd : m_supportedCmds) {
 		if (name == cmd->getName()) {

--- a/TestShell/TestShell/cmd_factory.h
+++ b/TestShell/TestShell/cmd_factory.h
@@ -5,7 +5,7 @@
 using std::string;
 using std::vector;
 
-class CmdInterface;
+class SsdInterface;
 
 class CmdFactory {
 public:
@@ -17,6 +17,8 @@ public:
 	void registerCmd(CmdInterface* cmd) {
 		m_supportedCmds.push_back(cmd);
 	}
+
+	void setSdd(SsdInterface* sdd);
 
 	CmdInterface* getCmd(const string& name) const;
 private :

--- a/TestShell/TestShell/cmd_interface.h
+++ b/TestShell/TestShell/cmd_interface.h
@@ -8,6 +8,8 @@
 using std::string;
 using std::vector;
 
+class SsdInterface;
+
 class CmdInterface {
 public:
 	CmdInterface(string name, int numToken) : m_name(name), m_numToken(numToken){
@@ -24,7 +26,12 @@ public:
 	}
 	const int MAX_LBA = 99;
 
+	void setSdd(SsdInterface* sdd) {
+		m_ssd = sdd;
+	}
 protected :
+	SsdInterface* m_ssd;
+
 	void checkNumToken(const vector<string>& tokens);
 	void checkLbaArg(const string& lbaString);
 	void checkDataArg(const string& dataString);

--- a/TestShell/TestShell/test_shell_app.cpp
+++ b/TestShell/TestShell/test_shell_app.cpp
@@ -1,6 +1,11 @@
 #include "test_shell_app.h"
 #include "cmd_factory.h"
 #include "cmd_interface.h"
+
+TestShellApp::TestShellApp(SsdInterface* m_ssd): m_ssd(m_ssd) {
+    CmdFactory::getInstance().setSdd(m_ssd);
+}
+
 void TestShellApp::writeCommand(const string& lba, const string& value) {
     m_ssd->writeData(lba, value);
 #ifndef _DEBUG

--- a/TestShell/TestShell/test_shell_app.h
+++ b/TestShell/TestShell/test_shell_app.h
@@ -15,9 +15,7 @@ using std::ifstream;
 
 class TestShellApp {
 public:
-	TestShellApp(SsdInterface* m_ssd)
-		: m_ssd(m_ssd) {
-	}
+	TestShellApp(SsdInterface* m_ssd);
 
 	bool cmdParserAndExcute(const string& cmdcmdString);
 	void writeCommand(const string& lba, const string& value);


### PR DESCRIPTION
🔍 **Pull Request**

### 변경 이유
cmd object가 ssd point를 가지고 있어야 함

### 주요 변경 내용
test shell app 생성자에서 cmd factory쪽으로 ssd를 넘겨서 
개별 cmd에 ssd를 셋팅할수 있도록 수정

### 테스트 방법
기존 TC 통과

- [ ] 단위 테스트 추가/수정
